### PR TITLE
feat: change cli options and `formal` signature

### DIFF
--- a/.changeset/metal-ties-applaud.md
+++ b/.changeset/metal-ties-applaud.md
@@ -1,0 +1,5 @@
+---
+"deeplx": patch
+---
+
+feat: change cli options and `formal` signature

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![Code Style: Prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 [![changesets](https://img.shields.io/badge/maintained%20with-changesets-176de3.svg)](https://github.com/atlassian/changesets)
 
-An unofficial Node package to translate text using [DeepL](https://www.deepl.com).
+An unofficial Node package to translate text using [DeepL](https://www.deepl.com) by porting [OwO-Network/DeepLX](https://github.com/OwO-Network/DeepLX).
 
 ## Online Service
 
@@ -65,6 +65,7 @@ Currently the following languages are supported:
 | SL           | Slovenian  | Slovenščina             |
 | ES           | Spanish    | Español                 |
 | SV           | Swedish    | Svenska                 |
+| UK           | Ukrainian  | Українська Мова         |
 
 You can either input the abbreviation or the language written in english.
 
@@ -73,22 +74,23 @@ You can either input the abbreviation or the language written in english.
 #### Help
 
 ```sh
-deeplx --help
+deeplx -h
 ```
 
-```log
+```console
 Usage: deeplx [options]
 
-An unofficial Node package to translate text using [DeepL](https://www.deeplx.com).
+An unofficial Node package to translate text using [DeepL](https://www.deepl.com) by porting [OwO-Network/DeepLX](https://github.com/OwO-Network/DeepLX).
 
 Options:
-  -V, --version                  output the version number
-  -sl, --source-language <text>  Source language of your text
-  -tl, --target-language <text>  Target language of your desired text
-  --formal                       Use formal or informal tone in translation (default: false)
-  -t, --text                     Text to be translated
-  -f, --file                     File to be translated
-  -h, --help                     display help for command
+  -V, --version        output the version number
+  -s, --source <text>  Source language of your text
+  -t, --target <text>  Target language of your desired text
+  --text <text>        Text to be translated
+  -f, --file <path>    File to be translated
+  --formal [boolean]   Whether to use formal (true) or informal (false) tone in translation. Default `undefined` respects source text tone.
+  --no-formal
+  -h, --help           display help for command
 ```
 
 #### Example 1
@@ -96,10 +98,10 @@ Options:
 This will translate a Spanish (`ES`) text into Russian (`RU`):
 
 ```sh
-deeplx -tl russian -t "¡Buenos días!"
+deeplx -t russian --text "¡Buenos días!"
 ```
 
-```plain
+```text
 Доброе утро!
 ```
 
@@ -108,7 +110,7 @@ deeplx -tl russian -t "¡Buenos días!"
 This will translate the file (`test.txt`) text from Italian (`IT`) into Portuguese (`PT`):
 
 ```sh
-deeplx -tl PT -f test.txt
+deeplx -t PT -f test.txt
 ```
 
 #### Example 3
@@ -116,10 +118,10 @@ deeplx -tl PT -f test.txt
 This will translate a Spanish (`ES`) text into Russian (`RU`) in _formal_ tone:
 
 ```sh
-deeplx -tl RU --text "¿Cómo te llamas?" --formal
+deeplx -t RU --text "¿Cómo te llamas?" --formal
 ```
 
-```plain
+```text
 Как Вас зовут?
 ```
 
@@ -130,10 +132,10 @@ Note: _informal_ would be "_Как **тебя** зовут?_"
 This will translate a Japanese (`JP`) text into German (`DE`) in _informal_ tone:
 
 ```sh
-deeplx -tl DE --text "お元気ですか？" --formal false
+deeplx -t DE --text "お元気ですか？" --no-formal
 ```
 
-```plain
+```text
 Wie geht es dir?
 ```
 
@@ -148,7 +150,7 @@ This will translate a Chinese (`ZH`) text into Dutch (`NL`):
 ```js
 import { translate } from 'deeplx'
 
-translate('你好', 'NL')
+await translate('你好', 'NL')
 ```
 
 ```log
@@ -162,7 +164,7 @@ This will translate a `danish` text into `german` in informal tone:
 ```js
 import { translate } from 'deeplx'
 
-translate('Ring til mig!', 'german', 'danish', undefined, undefined, false)
+await translate('Ring til mig!', 'german', 'danish', false)
 ```
 
 ```log

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "deeplx",
   "version": "0.2.0",
   "type": "module",
-  "description": "An unofficial Node package to translate text using [DeepL](https://www.deepl.com).",
+  "description": "An unofficial Node package to translate text using [DeepL](https://www.deepl.com) by porting [OwO-Network/DeepLX](https://github.com/OwO-Network/DeepLX).",
   "repository": "https://github.com/un-ts/deeplx.git",
   "author": "JounQin <admin@1stg.me> (https://www.1stG.me)",
   "funding": "https://opencollective.com/deeplx",
@@ -49,6 +49,7 @@
     "build": "run-p 'build:*'",
     "build:r": "r -f cjs",
     "build:tsc": "tsc -p tsconfig.lib.json",
+    "deeplx": "tsx src/cli.ts",
     "format": "prettier --write .",
     "lint": "run-p 'lint:*'",
     "lint:es": "eslint . --cache --max-warnings 10",
@@ -60,7 +61,7 @@
     "vercel-build": "yarn build && tsx scripts/build"
   },
   "dependencies": {
-    "@pkgr/core": "^0.2.1",
+    "@pkgr/core": "^0.2.2",
     "commander": "^13.1.0",
     "node-fetch": "^3.3.2",
     "tslib": "^2.8.1",

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,26 +1,13 @@
-import {
-  FORMALITY_TONES,
-  type FormalityTone,
-  type SourceLanguage,
-  type TargetLanguage,
-} from './constants.js'
+import type { SourceLanguage, TargetLanguage } from './constants.js'
 import { translateByDeepLX } from './translate.js'
 
 export const translate = async (
   text: string,
   targetLang: TargetLanguage,
   sourceLang?: SourceLanguage,
-  formalityTone?: FormalityTone,
+  formal?: boolean,
 ) => {
-  if (formalityTone && !FORMALITY_TONES.has(formalityTone)) {
-    throw new Error(`Formality tone \`${formalityTone}\` not supported.`)
-  }
-  const result = await translateByDeepLX(
-    sourceLang,
-    targetLang,
-    text,
-    formalityTone,
-  )
+  const result = await translateByDeepLX(sourceLang, targetLang, text, formal)
   if ('message' in result) {
     throw new Error(result.message, { cause: result })
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,37 +11,57 @@ import { program } from 'commander'
 import { translate } from './api.js'
 import type { SourceLanguage, TargetLanguage } from './constants.js'
 
-const { version, description } = cjsRequire<{
+export interface DeepLXCliOptions {
+  target: TargetLanguage
+  source?: SourceLanguage
+  text?: string
+  file?: string
+  formal?: boolean
+}
+
+const { name, version, description } = cjsRequire<{
+  name: string
   version: string
   description: string
 }>(fileURLToPath(new URL('../package.json', import.meta.url)))
 
+const FALSY_VALUES = new Set(['0', 'false', 'n', 'no', 'off'])
+
 program
+  .name(name)
   .version(version)
   .description(description)
-  .option('-sl, --source-language <text>', 'Source language of your text')
-  .option(
-    '-tl, --target-language <text>',
-    'Target language of your desired text',
-  )
-  .option('-t, --text <text>', 'Text to be translated')
+  .option('-s, --source <text>', 'Source language of your text')
+  .requiredOption('-t, --target <text>', 'Target language of your desired text')
+  .option('--text <text>', 'Text to be translated')
   .option('-f, --file <path>', 'File to be translated')
+  .option(
+    '--formal [boolean]',
+    'Whether to use formal (true) or informal (false) tone in translation. Default `undefined` respects source text tone.',
+    (formal?: string) => (formal == null ? formal : !FALSY_VALUES.has(formal)),
+  )
+  .option('--no-formal')
   .action(async function () {
-    const { sourceLanguage, targetLanguage, text, file } = this.opts<{
-      targetLanguage: TargetLanguage
-      sourceLanguage?: SourceLanguage
-      text?: string
-      file?: string
-    }>()
+    const { source, target, text, file, formal } = this.opts<DeepLXCliOptions>()
 
-    if (text == null && file == null) {
-      throw new Error('One of `text` or `file` option must be specificated')
+    const isTextNil = text == null || text.trim() === ''
+    const isFileNil = file == null || file.trim() === ''
+
+    if (isTextNil && isFileNil) {
+      throw new Error('One of `text` or `file` option must be specified')
+    }
+
+    if (!isTextNil && !isFileNil) {
+      console.warn(
+        'Both `text` and `file` options provided, `text` will take precedence',
+      )
     }
 
     const translated = await translate(
-      text == null ? await fs.readFile(file!, 'utf8') : text,
-      targetLanguage,
-      sourceLanguage,
+      isTextNil ? await fs.readFile(file!, 'utf8') : text,
+      target,
+      source,
+      formal,
     )
 
     console.log(translated)

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -34,7 +34,11 @@ export type SupportedLanguage = ValueOf<typeof SUPPORTED_LANGUAGES>
 
 export type SupportedCode = SupportedLanguage['code']
 
-export type Language = SupportedCode | SupportedLanguage['language']
+export type Language =
+  | SupportedCode
+  | SupportedLanguage['language']
+  // language code with variant
+  | `${SupportedCode}-${string}`
 
 export type TargetLanguage =
   | Language

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -7,7 +7,6 @@ import {
   HTTP_STATUS_NOT_FOUND,
   HTTP_STATUS_OK,
   HTTP_STATUS_SERVICE_UNAVAILABLE,
-  type FormalityTone,
   type SourceLanguage,
   type SupportedCode,
   type TargetLanguage,
@@ -49,7 +48,7 @@ export const translateByDeepLX = async (
   sourceLang: SourceLanguage | undefined,
   targetLang: TargetLanguage,
   text: string,
-  formalityTone?: FormalityTone,
+  formal?: boolean,
   tagHandling = 'plaintext',
   proxyUrl?: string,
   dlSession?: string,
@@ -111,7 +110,9 @@ export const translateByDeepLX = async (
       params: {
         commonJobParams: {
           mode: 'translate',
-          formality: String(formalityTone) as FormalityTone,
+          formality:
+            // eslint-disable-next-line sonarjs/no-nested-conditional
+            formal == null ? 'undefined' : formal ? 'formal' : 'informal',
           transcribe_as: 'romanize',
           advancedMode: false,
           textType: tagHandling,

--- a/test/translation.spec.ts
+++ b/test/translation.spec.ts
@@ -10,35 +10,35 @@ function randRange(min: number, max: number) {
 beforeEach(() => setTimeout(randRange(500, 1000)))
 
 test('translate russian', async () => {
-  const source_language = 'RU'
-  const target_language = 'EN'
+  const sourceLang = 'RU'
+  const targetLang = 'EN'
   const text = 'Я сошла с ума'
-  const translation = await translate(text, target_language, source_language)
+  const translation = await translate(text, targetLang, sourceLang)
   expect(translation).toMatchInlineSnapshot(`"I've lost my mind"`)
 })
 
 test('translate chinese', async () => {
-  const source_language = 'ZH'
-  const target_language = 'dutch'
+  const sourceLang = 'ZH'
+  const targetLang = 'dutch'
   const text = '你好'
-  const translation = await translate(text, target_language, source_language)
+  const translation = await translate(text, targetLang, sourceLang)
   expect(translation).toMatchInlineSnapshot(`"Hoe gaat het met je?"`)
 })
 
 test('translate greek romanian', async () => {
-  const source_language = 'gReEk'
-  const target_language = 'rO'
+  const sourceLang = 'gReEk'
+  const targetLang = 'rO'
   const text = 'Γεια σας'
   // @ts-expect-error -- only upper, lower or capitalize case languages are supported in TypeScript
-  const translation = await translate(text, target_language, source_language)
+  const translation = await translate(text, targetLang, sourceLang)
   expect(translation).toMatchInlineSnapshot(`"Bună ziua."`)
 })
 
 test('translate sentence', async () => {
   const text = 'Up and down.'
-  expect(await translate(text, 'NL', 'EN')).toMatchInlineSnapshot(
-    `"Op en neer."`,
-  )
+  const expected_translations = ['Op en neer.', 'Omhoog en omlaag.']
+  const translation = await translate(text, 'NL', 'EN')
+  expect(expected_translations).toContain(translation)
 })
 
 test('translate sentences', async () => {
@@ -83,16 +83,3 @@ test('informal german translation', async () => {
   const translation = await translate(text, 'DE')
   expect(expected_translations).toContain(translation)
 })
-
-test('invalid_formal_tone', () =>
-  expect(
-    translate(
-      'ABC',
-      'DE',
-      'EN',
-      // @ts-expect-error -- intended
-      'politically incorrect',
-    ),
-  ).rejects.toThrowErrorMatchingInlineSnapshot(
-    `[Error: Formality tone \`politically incorrect\` not supported.]`,
-  ))

--- a/yarn.lock
+++ b/yarn.lock
@@ -3441,10 +3441,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pkgr/core@npm:^0.2.0, @pkgr/core@npm:^0.2.1":
-  version: 0.2.1
-  resolution: "@pkgr/core@npm:0.2.1"
-  checksum: 10c0/760fcb5999a1794179ad7f498dfc342f9135b846d096bda43f07d4278d5557e87e7c889f5670d1338a802dffcc6a52548cc9be3fbd97d68ce3b3901d5d6160cd
+"@pkgr/core@npm:^0.2.0, @pkgr/core@npm:^0.2.1, @pkgr/core@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "@pkgr/core@npm:0.2.2"
+  checksum: 10c0/86a0507731f2c5172e2225abb42d947b3908d06f0330e7050b5e6ad0c29dab4d586358f2d984aa00fd32bf421ed3405fa97878b352f16c3c23d20398b5fd14e4
   languageName: node
   linkType: hard
 
@@ -6363,7 +6363,7 @@ __metadata:
     "@changesets/cli": "npm:^2.28.1"
     "@commitlint/cli": "npm:^19.8.0"
     "@octokit/request": "npm:^9.2.2"
-    "@pkgr/core": "npm:^0.2.1"
+    "@pkgr/core": "npm:^0.2.2"
     "@pkgr/rollup": "npm:^6.0.2"
     "@types/web": "npm:^0.0.216"
     "@vercel/node": "npm:^5.1.14"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Ukrainian as a translation language.
  - Introduced a new command to run the translation tool.

- **Documentation**
  - Updated the command line help with clearer option names (--source, --target, --formal) and expanded the package description.

- **Refactor**
  - Simplified translation configuration by replacing tone-based options with a straightforward boolean flag.
  - Expanded language support to recognize variant language code formats.

- **Bug Fixes**
  - Removed outdated test case for unsupported formality tones.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->