### PR TITLE
fix: use static consistent cli name

### DIFF
--- a/.changeset/swift-bulldogs-admire.md
+++ b/.changeset/swift-bulldogs-admire.md
@@ -1,0 +1,5 @@
+---
+"@deeplx/cli": patch
+---
+
+fix: use static consistent cli name

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ deeplx -h
 ```console
 Usage: deeplx [options]
 
-An unofficial Node package to translate text using [DeepL](https://www.deepl.com) by porting [OwO-Network/DeepLX](https://github.com/OwO-Network/DeepLX).
+The cli for [`@deeplx/core`](https://github.com/un-ts/deeplx/blob/master/packages/@deeplx/core).
 
 Options:
   -V, --version        output the version number

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:r": "r -f cjs",
     "build:tsc": "tsc -b tsconfig.lib.json",
     "clean": "rimraf --glob .type-coverage coverage '.*cache' 'packages/**/{lib,*.tsbuildinfo}'",
-    "deeplx": "tsx packages/deeplx/src/cli.ts",
+    "deeplx": "tsx packages/@deeplx/cli/src/cli.ts",
     "format": "prettier --write .",
     "lint": "run-p 'lint:*'",
     "lint:es": "eslint . --cache --max-warnings 10",

--- a/packages/@deeplx/cli/README.md
+++ b/packages/@deeplx/cli/README.md
@@ -78,7 +78,7 @@ deeplx -h
 ```console
 Usage: deeplx [options]
 
-An unofficial Node package to translate text using [DeepL](https://www.deepl.com) by porting [OwO-Network/DeepLX](https://github.com/OwO-Network/DeepLX).
+The cli for [`@deeplx/core`](https://github.com/un-ts/deeplx/blob/master/packages/@deeplx/core).
 
 Options:
   -V, --version        output the version number

--- a/packages/@deeplx/cli/package.json
+++ b/packages/@deeplx/cli/package.json
@@ -11,7 +11,9 @@
   "engines": {
     "node": "^12.20 || ^14.18.0 || >=16.0.0"
   },
-  "bin": "./lib/cli.js",
+  "bin": {
+    "deeplx": "./lib/cli.js"
+  },
   "exports": {
     ".": {
       "types": "./lib/cli.d.ts",

--- a/packages/@deeplx/cli/src/cli.ts
+++ b/packages/@deeplx/cli/src/cli.ts
@@ -21,8 +21,7 @@ export interface DeepLXCliOptions {
   formal?: boolean
 }
 
-const { name, version, description } = cjsRequire<{
-  name: string
+const { version, description } = cjsRequire<{
   version: string
   description: string
 }>(fileURLToPath(new URL('../package.json', import.meta.url)))
@@ -30,7 +29,7 @@ const { name, version, description } = cjsRequire<{
 const FALSY_VALUES = new Set(['0', 'false', 'n', 'no', 'off'])
 
 program
-  .name(name)
+  .name('deeplx')
   .version(version)
   .description(description)
   .option('-s, --source <text>', 'Source language of your text')

--- a/yarn.lock
+++ b/yarn.lock
@@ -2338,7 +2338,7 @@ __metadata:
     commander: "npm:^13.1.0"
     node-fetch: "npm:^3.3.2"
   bin:
-    cli: ./lib/cli.js
+    deeplx: ./lib/cli.js
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured the CLI consistently uses a static name, reducing potential confusion during command execution.
- **Documentation**
  - Updated the CLI usage descriptions and instructions to clearly reflect its association with the core package.

These improvements provide a more predictable command-line experience and clearer guidance for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->