### PR TITLE
feat: support AbortSignal in translate

### DIFF
--- a/.changeset/eight-doors-fly.md
+++ b/.changeset/eight-doors-fly.md
@@ -1,5 +1,5 @@
 ---
-"@deeplx/core": minor
+"@deeplx/core": patch
 ---
 
 feat: support `AbortSignal` in translate to allow cancellation of upstream requests

--- a/.changeset/eight-doors-fly.md
+++ b/.changeset/eight-doors-fly.md
@@ -1,0 +1,5 @@
+---
+"@deeplx/core": minor
+---
+
+feat: support `AbortSignal` in translate to allow cancellation of upstream requests

--- a/packages/@deeplx/core/src/api.ts
+++ b/packages/@deeplx/core/src/api.ts
@@ -4,6 +4,7 @@ import { translateByDeepLX } from './translate.ts'
 export interface TranslateOptions {
   dlSession?: string
   proxyUrl?: string
+  signal?: AbortSignal
 }
 
 export const translate = async (
@@ -18,6 +19,7 @@ export const translate = async (
     text,
     options?.proxyUrl,
     options?.dlSession,
+    options?.signal,
   )
   if ('message' in result) {
     throw new Error(result.message, { cause: result })

--- a/packages/@deeplx/core/src/translate.ts
+++ b/packages/@deeplx/core/src/translate.ts
@@ -37,7 +37,7 @@ function getInstanceID(): string {
 let sharedCookies = ''
 let warmupPromise: Promise<void> | null = null
 
-async function warmCookies(proxyUrl?: string, signal?: AbortSignal) {
+async function warmCookies(proxyUrl?: string) {
   if (warmupPromise !== null) {
     return warmupPromise
   }
@@ -45,7 +45,6 @@ async function warmCookies(proxyUrl?: string, signal?: AbortSignal) {
     try {
       const res = await xfetch('https://www.deepl.com/translator', {
         type: null,
-        signal,
         ...createProxy({ url: proxyUrl }),
       })
       const setCookie = res.headers.get('set-cookie')
@@ -201,7 +200,7 @@ export const translateByDeepLX = async (
   }
 
   if (!dlSession) {
-    await warmCookies(proxyUrl, signal)
+    await warmCookies(proxyUrl)
   }
 
   const targetResult = resolveLang(targetLang, 'target')

--- a/packages/@deeplx/core/src/translate.ts
+++ b/packages/@deeplx/core/src/translate.ts
@@ -37,7 +37,7 @@ function getInstanceID(): string {
 let sharedCookies = ''
 let warmupPromise: Promise<void> | null = null
 
-async function warmCookies(proxyUrl?: string) {
+async function warmCookies(proxyUrl?: string, signal?: AbortSignal) {
   if (warmupPromise !== null) {
     return warmupPromise
   }
@@ -45,6 +45,7 @@ async function warmCookies(proxyUrl?: string) {
     try {
       const res = await xfetch('https://www.deepl.com/translator', {
         type: null,
+        signal,
         ...createProxy({ url: proxyUrl }),
       })
       const setCookie = res.headers.get('set-cookie')
@@ -186,6 +187,7 @@ export const translateByDeepLX = async (
   text: string,
   proxyUrl?: string,
   dlSession?: string,
+  signal?: AbortSignal,
 ): Promise<DeepLXTranslationResult> => {
   if (!text) {
     return { code: HTTP_STATUS_NOT_FOUND, message: 'No text to translate' }
@@ -199,7 +201,7 @@ export const translateByDeepLX = async (
   }
 
   if (!dlSession) {
-    await warmCookies(proxyUrl)
+    await warmCookies(proxyUrl, signal)
   }
 
   const targetResult = resolveLang(targetLang, 'target')
@@ -235,6 +237,7 @@ export const translateByDeepLX = async (
         method: 'POST',
         body: reqData,
         headers: buildHeaders(dlSession),
+        signal,
         ...createProxy({ url: proxyUrl }),
       },
     )

--- a/worker.ts
+++ b/worker.ts
@@ -98,6 +98,7 @@ export default {
         text,
         proxyUrl,
         dlSession,
+        req.signal,
       )
 
       return json(result, result.code)

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,7 +1,7 @@
 name = "deeplx"
 main = "worker.ts"
 compatibility_date = "2025-06-26"
-compatibility_flags = ["nodejs_compat"]
+compatibility_flags = ["nodejs_compat", "enable_request_signal"]
 
 [assets]
 directory = "./public"


### PR DESCRIPTION
### Description

Add `AbortSignal` support to `translate`, closes #51.

### Changes

- **Core**: Added a `signal` option to `TranslateOptions` and forwarded it to the underlying `xfetch` requests.
- **Worker**: Enabled `enable_request_signal` in `wrangler.toml` and automatically forwarded `req.signal` to `translateByDeepLX`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Translation requests now support cancellation via `AbortSignal`, allowing in-progress translations to be stopped when the original request is aborted.
* **Bug Fixes**
  * Cancellation is now propagated through the full translation flow, including the initial startup/warmup step and the main translation request.
* **Chores**
  * Updated runtime configuration to enable request signal support alongside existing compatibility settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->