### PR TITLE
Potential fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+  pull-requests: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/un-ts/deeplx/security/code-scanning/19](https://github.com/un-ts/deeplx/security/code-scanning/19)

Add an explicit `permissions` block to `.github/workflows/size-limit.yml` at the workflow root so it applies to all jobs (including `size-limit`).  
Best minimal fix (without changing functionality) is to grant:

- `contents: read` (recommended baseline for checkout/read operations)
- `pull-requests: write` (commonly needed by size-limit actions to post/update PR comments/status)

Place this block after `on:` (or before `jobs:`) at top-level indentation.

No imports, methods, or dependencies are required (YAML config-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflow permissions to use a more explicit and limited access scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->