### PR TITLE
Potential fix for code scanning alert no. 18: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -4,6 +4,9 @@ on:
   - push
   - pull_request
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/un-ts/deeplx/security/code-scanning/18](https://github.com/un-ts/deeplx/security/code-scanning/18)

Add an explicit `permissions` block in `.github/workflows/pkg-pr-new.yml` to restrict `GITHUB_TOKEN` scopes.  
Best single fix without changing functionality: set workflow-level minimal permission `contents: read`, as recommended by CodeQL/GitHub for workflows that need repository read access (e.g., checkout). This applies to all jobs unless overridden and preserves existing steps/behavior while removing implicit broad token rights.

Change location:
- File: `.github/workflows/pkg-pr-new.yml`
- Insert directly after the `on:` trigger block (before `concurrency:`) a root-level:
  - `permissions:`
  - `contents: read`

No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
