### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   - push
   - pull_request
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/un-ts/deeplx/security/code-scanning/17](https://github.com/un-ts/deeplx/security/code-scanning/17)

Add an explicit workflow-level `permissions` block in `.github/workflows/ci.yml`, directly under the `on:` section (or before `jobs:`), to enforce least privilege for all jobs unless overridden.

Best single fix without changing behavior:
- Add:
  - `permissions:`
  - `  contents: read`

Why this is best:
- It addresses the CodeQL finding directly.
- It preserves existing workflow functionality for checkout/build/test flows.
- It documents token scope and prevents future default changes from silently broadening permissions.
- No imports/dependencies/method changes are needed (YAML-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
