### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -11,6 +11,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   autofix:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/un-ts/deeplx/security/code-scanning/16](https://github.com/un-ts/deeplx/security/code-scanning/16)

Add an explicit `permissions` block to `.github/workflows/autofix.yml` at the workflow root (recommended here since there is a single job).  
Because this workflow runs `autofix-ci` to apply and push fixes back to pull requests, it needs more than read-only access to repository contents. The safest practical fix without changing behavior is:

- `contents: write` (to commit/push autofixes)
- `pull-requests: write` (to update PR branch/metadata as needed by autofix workflows)

Place this block after `concurrency` (or before `jobs`) so it applies to all jobs unless overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
