### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pkg-size.yml
+++ b/.github/workflows/pkg-size.yml
@@ -3,6 +3,9 @@ name: Package Size Report
 on:
   - pull_request
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/un-ts/deeplx/security/code-scanning/15](https://github.com/un-ts/deeplx/security/code-scanning/15)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is scoped intentionally instead of inheriting defaults.  
Best single fix here: define permissions at the workflow root (applies to all jobs unless overridden) with least privilege needed by this workflow. Since the CodeQL alert suggests a minimal baseline and the shown steps only require repository read access to check out code and run reporting, set:

- `contents: read`

Edit **`.github/workflows/pkg-size.yml`**, inserting the block after the trigger section (`on:`) and before `concurrency:`. No imports/dependencies/methods are needed (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
